### PR TITLE
Remove S3Upload and SbtRelease from default settings

### DIFF
--- a/src/main/scala/com/playi/SbtPlayI.scala
+++ b/src/main/scala/com/playi/SbtPlayI.scala
@@ -32,8 +32,6 @@ object SbtPlayI extends Plugin {
     coreBuildSettings       ++ 
     PlayIBuildInfo.settings ++ 
     Resolvers.settings      ++ 
-    PlayIS3Upload.settings  ++ 
-    PlayIRelease.settings   ++
     net.virtualvoid.sbt.graph.Plugin.graphSettings
 }
 


### PR DESCRIPTION
These plugins cause a lot of problems when imported into other projects
by default. The primary issue is something like:

```
[info] Loading project definition from /Users/gavares/workspace/playi/orders/project
Reference to undefined setting:

  api/universal:packageZipTarball from api/*:s3Upload::mappings
                                            (/Users/gavares/workspace/playi/orders/api/build.sbt:16)
```

We also end up importing a bunch of uneeded settings in _every_ project
just to silence these errors.

Instead, the projects that need either S3Upload or
SbtNativePackger/SbtRelease can import those settings on demand by
putting a line like:

```
com.playi.S3Upload.settings
```

into their build.sbt files.
